### PR TITLE
index: redirect to /dashboard/login instead of rendering 'Hello'

### DIFF
--- a/packages/testbed2/src/pages/index.js
+++ b/packages/testbed2/src/pages/index.js
@@ -1,9 +1,24 @@
 // @flow
+import Router from 'next/router';
 
-import React from 'react';
+import type { InitialPropsContext } from '../utils/nextTypes';
 
-function Test(): React$Element<'div'> {
-  return <div>Hello</div>;
+const redirectTo = (res, path) => {
+  if (res) {
+    res.writeHead(302, { Location: path });
+    res.end();
+  } else {
+    Router.push(path);
+  }
+};
+
+function Test(): React$Node {
+  return null;
 }
+
+Test.getInitialProps = ({ res }: InitialPropsContext) => {
+  redirectTo(res, '/dashboard/login');
+  return {};
+};
 
 export default Test;


### PR DESCRIPTION
This is more useful default behaviour for getting started with the project, methinks.

Redirecting by writing to `res` in `getInitialProps` is, apparently, the recommended way of doing this in next.js