### PR TITLE
Rewrote useScrollFix

### DIFF
--- a/packages/next-dashboard/src/components/layout/Main.js
+++ b/packages/next-dashboard/src/components/layout/Main.js
@@ -89,7 +89,7 @@ function DashboardLayout({
     };
   }, [modalActive]);
 
-  const style = useScrollFix(modalActive);
+  const scrollRef = useScrollFix(modalActive);
 
   return (
     <div
@@ -98,7 +98,7 @@ function DashboardLayout({
         id && `dashboard_id-${id}`,
         themeClass && `dashboard_theme-${themeClass}`,
       ])}
-      style={style}
+      ref={scrollRef}
     >
       <Head>
         <link

--- a/packages/next-dashboard/src/utils/useScrollFix.js
+++ b/packages/next-dashboard/src/utils/useScrollFix.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 export default function useScrollFix(
   shouldFix: boolean,


### PR DESCRIPTION
Okay, I know using refs and directly modifying the DOM isn't advised in React, but considering the fact that we want to both change the style, in the DOM, AND run "window.scrollTo" during the same frame/whatever to ensure that no jittery or jerkiness occurs between the updated style, and the scrolling. I think this approach, while it might not follow React best practices, is the best solution for this time sensitive operation in this case.

It's also way less "hacky" in the sense that we don't rely on reacts render timings.