### PR TITLE
TEMP FIX: Reinit auth on new requests

### DIFF
--- a/packages/next-dashboard/src/utils/createDashboardHOC.js
+++ b/packages/next-dashboard/src/utils/createDashboardHOC.js
@@ -281,14 +281,13 @@ export default function createDashboardHOC({
       InitialProps<$Shape<I> | {}>,
     > = async ctx => {
       if (!authInitialized && errorAuthReporter.initialize) {
-        if (process.env.NODE_ENV === 'development') {
-          // Workaround for dev server not cleaning up properly between renders
-          setTimeout(() => {
-            authInitialized = false;
-          }, 10);
-        }
         authInitialized = true;
         errorAuthReporter.initialize(ctx);
+        // Workaround for auth leaking. NOT PERMANENT SOLUTION!
+        // WILL FIX AFTER VACATION
+        setTimeout(() => {
+          authInitialized = false;
+        }, 10);
       }
       const { pathname, query, asPath } = ctx;
       const authenticated =


### PR DESCRIPTION
Okay, turns out this issue wasn't isolated to development mode servers.

Fixing this properly will require some major restructuring of the underlaying auth-management code. Luckily most things that use the authProvider is abstracted away, meaning we can rewrite the core, and have everything else magically work.

At any rate, not something I can fix in less than 2 hours, so a hotfix so our client can still see potential progress that's made when I'm gone without having weird authentication issues all the time will probably be nice.