### PR TITLE
Fixed typings for AuthProvider

### DIFF
--- a/packages/next-dashboard/src/utils/createDashboardHOC.js
+++ b/packages/next-dashboard/src/utils/createDashboardHOC.js
@@ -243,7 +243,18 @@ export default function createDashboardHOC({
         theme,
         modalActive,
         setModalActive,
-        authProvider,
+        getAuthProvider<A: IAuthProvider>(C: Class<A>): A | void {
+          if (authProvider === undefined) return undefined;
+          if (authProvider instanceof C) return authProvider;
+          if (process.env.NODE_ENV === 'development') {
+            console.error(
+              new Error(
+                'AuthProvider mismatch, instance not of requested class',
+              ),
+            );
+          }
+          return undefined;
+        },
       };
       // eslint-disable-next-line no-underscore-dangle,react/destructuring-assignment
       if (props.__ERRORED__) {

--- a/packages/next-dashboard/src/utils/dashboardContext.js
+++ b/packages/next-dashboard/src/utils/dashboardContext.js
@@ -1,5 +1,9 @@
 // @flow
 import React from 'react';
+
+// eslint fails to parse `getAuthProvider<T: IAuthProvider>`
+// as this type being used...
+// eslint-disable-next-line no-unused-vars
 import type { Theme, SiteMessageType, IAuthProvider } from './types';
 
 export interface IDashboardContext {
@@ -13,7 +17,7 @@ export interface IDashboardContext {
   +siteMessages: $ReadOnlyArray<SiteMessageType>;
   +modalActive: boolean;
   setModalActive((boolean => boolean) | boolean): void;
-  authProvider: IAuthProvider;
+  getAuthProvider<T: IAuthProvider>(Class: Class<T>): T | void;
 }
 
 export type DashboardContextType = IDashboardContext | void;

--- a/packages/next-dashboard/src/utils/types.js
+++ b/packages/next-dashboard/src/utils/types.js
@@ -96,8 +96,6 @@ export interface IAuthProvider {
     _query: { [string]: string | void },
   ): boolean;
   isAuthenticated(): boolean;
-  deAuth(): void;
-  auth<Args: $ReadOnlyArray<*>>(...args: Args): Promise<boolean>;
 }
 
 export type DashboardInitialPropsContext = InitialPropsContext & {


### PR DESCRIPTION
Old way of doing authProvider was hard to type and generally unversatile. Made it better now