### PR TITLE
PieChart: migrate from child project

### DIFF
--- a/packages/next-dashboard/sass/components/_pie-chart.scss
+++ b/packages/next-dashboard/sass/components/_pie-chart.scss
@@ -1,0 +1,39 @@
+.pie-chart-title-container {
+  font-size: 16px;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 16px;
+}
+
+.pie-chart-types-list {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-top: 10px;
+  margin-top: 10px;
+  border-top: 1px solid rgba(151, 151, 151, 0.4);
+}
+
+.pie-chart-type {
+  list-style: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 10px;
+}
+
+.pie-chart-type-color {
+  margin-right: 10px;
+  height: 10px;
+  width: 10px;
+  border-radius: 10px;
+}
+
+.pie-chart-label-line {
+  stroke-width: 3;
+  stroke-linecap: round;
+}
+.pie-chart-label-text {
+  font-size: 16px;
+  @include var('fill', 'text');
+}

--- a/packages/next-dashboard/sass/index.scss
+++ b/packages/next-dashboard/sass/index.scss
@@ -60,6 +60,7 @@
 @import 'components/site-message';
 @import 'components/faq';
 @import 'components/line-chart';
+@import 'components/pie-chart';
 @import 'components/vertical-bar-chart';
 @import 'components/hamburger-menu';
 

--- a/packages/next-dashboard/src/components/PieChart.js
+++ b/packages/next-dashboard/src/components/PieChart.js
@@ -1,0 +1,108 @@
+// @flow
+import React from 'react';
+import {
+  Legend,
+  Pie,
+  PieChart as RechartPieChart,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts';
+import PageChart from './PageChart';
+
+type Props = {
+  plots: {
+    name: string,
+    fill: string,
+    stroke: string,
+    value: ?number,
+  }[],
+  children?: React$Node,
+};
+
+const RADIAN = Math.PI / 180;
+const renderCustomizedLabel = ({
+  cx,
+  cy,
+  midAngle,
+  innerRadius,
+  outerRadius,
+  percent,
+  fill,
+}: {
+  cx: number,
+  cy: number,
+  midAngle: number,
+  innerRadius: number,
+  outerRadius: number,
+  percent: number,
+  fill: string,
+}) => {
+  const radius = innerRadius + (outerRadius - innerRadius) * 1.25;
+  const x = cx + radius * Math.cos(-midAngle * RADIAN);
+  const y = cy + radius * Math.sin(-midAngle * RADIAN);
+
+  return (
+    <g transform={`translate(${x}, ${y})`}>
+      <text
+        textAnchor={x > cx ? 'start' : 'end'}
+        dominantBaseline="central"
+        className="pie-chart-label-text"
+      >
+        {Math.round(percent * 100)}%
+      </text>
+      <line
+        x1={x > cx ? 30 : -30}
+        x2="0"
+        y1="15"
+        y2="15"
+        className="pie-chart-label-line"
+        style={{ stroke: fill }}
+      />
+    </g>
+  );
+};
+
+export default function PieChart({
+  plots,
+  children,
+}: Props): React$Element<typeof PageChart> {
+  return (
+    <PageChart>
+      <ResponsiveContainer>
+        <RechartPieChart>
+          {children}
+          <Tooltip isAnimationActive={false} />
+          <Legend
+            key="pie-chart-key"
+            verticalAlign="bottom"
+            iconType="circle"
+            content={({ payload }) => (
+              <ul className="pie-chart-types-list">
+                {payload.map(entry => (
+                  <li key={entry.value} className="pie-chart-type">
+                    <div
+                      className="pie-chart-type-color"
+                      style={{ backgroundColor: entry.color }}
+                    />
+                    {entry.value}
+                  </li>
+                ))}
+              </ul>
+            )}
+          />
+          <Pie
+            data={plots}
+            dataKey="value"
+            nameKey="name"
+            labelLine={false}
+            label={renderCustomizedLabel}
+          />
+        </RechartPieChart>
+      </ResponsiveContainer>
+    </PageChart>
+  );
+}
+
+PieChart.defaultProps = {
+  children: undefined,
+};

--- a/packages/next-dashboard/src/components/index.js
+++ b/packages/next-dashboard/src/components/index.js
@@ -17,5 +17,6 @@ export { default as ResponsiveTable } from './ResponsiveTable';
 export { default as PageChart } from './PageChart';
 export { default as SiteMessage } from './SiteMessage';
 export { default as LineChart } from './LineChart';
+export { default as PieChart } from './PieChart';
 export { default as Chart } from './Chart';
 export { default as VerticalBarChart } from './VerticalBarChart';


### PR DESCRIPTION
Moving the PieChart to next-dashboard for reusability reasons as well as to fix a sass dependency.