### PR TITLE
Added linting of style files

### DIFF
--- a/packages/next-dashboard/.stylelintrc.js
+++ b/packages/next-dashboard/.stylelintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  extends: 'stylelint-config-recommended',
+  rules: {
+    'at-rule-no-unknown': [
+      true,
+      {
+        ignoreAtRules: ['include', 'each', 'for', 'extend', 'mixin', 'warn', 'function', 'return', 'if', 'else'],
+      },
+    ]
+  },
+};

--- a/packages/next-dashboard/sass/base/_grid.scss
+++ b/packages/next-dashboard/sass/base/_grid.scss
@@ -1,3 +1,12 @@
+.cell {
+  flex: 0 0 100%;
+  max-width: 100%;
+  padding: #{map-get($grid-sizes, $grid-default-size) / 2}px;
+  &:empty {
+    padding: 0;
+  }
+}
+
 .grid {
   display: flex;
   flex-wrap: wrap;
@@ -6,15 +15,6 @@
     &:empty {
       padding: 0;
     }
-  }
-}
-
-.cell {
-  flex: 0 0 100%;
-  max-width: 100%;
-  padding: #{map-get($grid-sizes, $grid-default-size) / 2}px;
-  &:empty {
-    padding: 0;
   }
 }
 

--- a/packages/next-dashboard/sass/components/_feature-box.scss
+++ b/packages/next-dashboard/sass/components/_feature-box.scss
@@ -30,7 +30,7 @@
     text-align: center;
     justify-content: center;
     align-items: center;
-    border-radius: 20px;;
+    border-radius: 20px;
     i {
       font-size: 2rem;
     }

--- a/packages/next-dashboard/sass/components/_hamburger-menu.scss
+++ b/packages/next-dashboard/sass/components/_hamburger-menu.scss
@@ -27,20 +27,6 @@
     --offset: -38;
 }
 
-.hamburger-menu input:checked+svg .line--1,
-.hamburger-menu input:checked+svg .line--3 {
-    --length: 22.627416998;
-}
-
-.hamburger-menu input:checked+svg .line--2 {
-    --length: 0;
-}
-
-.back input:checked+svg .line--1,
-.back input:checked+svg .line--3 {
-    --length: 8.602325267;
-}
-
 .hamburger-menu .line--1,
 .hamburger-menu .line--3 {
     --total-length: 126.64183044433594;
@@ -52,9 +38,16 @@
 
 .hamburger-menu input:checked+svg .line--1,
 .hamburger-menu input:checked+svg .line--3 {
+    --length: 22.627416998;
     --offset: -94.1149185097;
 }
 
 .hamburger-menu input:checked+svg .line--2 {
+    --length: 0;
     --offset: -50;
+}
+
+.back input:checked+svg .line--1,
+.back input:checked+svg .line--3 {
+    --length: 8.602325267;
 }

--- a/packages/next-dashboard/sass/components/_page-table.scss
+++ b/packages/next-dashboard/sass/components/_page-table.scss
@@ -7,57 +7,55 @@
       @include var('border-color', 'text-rgb', 'rgba', 0.125);
       border-right: none;
     }
+    th {
+      padding-top: 20px;
+      padding-bottom: 20px;
+    }
+    th, td {
+      padding: 27px 15px;
+    }
+    thead th {
+      padding-top: 15px;
+      padding-bottom: 15px;
+      position: relative;
+      top: inherit;
+      @include var('background-color', 'tertiary-alt');
+      font-weight: 600;
+      text-transform: uppercase;
+      &.sort:after {
+        font-weight: 900;
+        font-family: "Font Awesome 5 Free", sans-serif;
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        display: inline-block;
+        font-style: normal;
+        font-variant: normal;
+        text-rendering: auto;
+        line-height: 1;
+        content: "";
+      }
+      &.sort-desc:after {
+        content: "\f0dd";
+      }
+      &.sort-asc:after {
+        content: "\f0de";
+      }
+    }
+    th:first-child, td:first-child {
+      padding-left: 30px;
+    }
+    th:last-child, td:last-child {
+      padding-right: 30px;
+    }
+    thead tr {
+      top: inherit;
+    }
     tbody {
       >tr {
         border-bottom: 1px solid;
         @include var('border-color', 'text-rgb', 'rgba', 0.125);
         &:last-child {
           border: none;
-        }
-      }
-    }
-    th, td {
-      padding: 27px 15px;
-      &:first-child {
-        padding-left: 30px;
-      }
-      &:last-child {
-        padding-right: 30px;
-      }
-    }
-    th {
-      padding-top: 20px;
-      padding-bottom: 20px;
-    }
-    thead {
-      tr {
-        top: inherit;
-      }
-      th {
-        padding-top: 15px;
-        padding-bottom: 15px;
-        position: relative;
-        top: inherit;
-        @include var('background-color', 'tertiary-alt');
-        font-weight: 600;
-        text-transform: uppercase;
-        &.sort:after {
-          font-weight: 900;
-          font-family: "Font Awesome 5 Free";
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          display: inline-block;
-          font-style: normal;
-          font-variant: normal;
-          text-rendering: auto;
-          line-height: 1;
-          content: "";
-        }
-        &.sort-desc:after {
-          content: "\f0dd";
-        }
-        &.sort-asc:after {
-          content: "\f0de";
         }
       }
     }

--- a/packages/next-dashboard/sass/components/_select.scss
+++ b/packages/next-dashboard/sass/components/_select.scss
@@ -39,7 +39,7 @@
     overflow: hidden;
   }
   &__multi-value {
-    @include var('background-color', 'background');;
+    @include var('background-color', 'background');
     border-radius: 2px;
     display: flex;
     margin: 2px;

--- a/packages/next-dashboard/sass/elements/_elements.scss
+++ b/packages/next-dashboard/sass/elements/_elements.scss
@@ -48,16 +48,16 @@ p {
 }
 
 ul,
+ol {
+  padding-left: 20px;
+}
+ul,
 ol,
 dl {
   margin: 0 0 20px;
   &:last-child {
     margin-bottom: 0;
   }
-}
-ul,
-ol {
-  padding-left: 20px;
 }
 dd {
   margin-left: 20px;

--- a/packages/next-dashboard/sass/elements/_headings.scss
+++ b/packages/next-dashboard/sass/elements/_headings.scss
@@ -1,24 +1,3 @@
- h1, h2, h3, h4, h5, h6,
-.h1, .h2, .h3, .h4, .h5, .h6 {
-  margin: 0 0 20px;
-  @include var('color', 'text');
-  font-weight: 700;
-  line-height: 1;
-  word-break: break-word;
-  text-rendering: optimizeLegibility;
-  &:last-child {
-    margin-bottom: 0;
-  }
-}
-p,
-ul,
-ol {
-  +h2, +h3
-  +.h2, +.h3 {
-    margin-top: 40px;
-  }
-}
-
 h1, .h1, .h1-size {
   font-size: 3.2rem;
 }
@@ -36,4 +15,20 @@ h5, .h5, .h5-size {
 }
 h6, .h6, .h6-size {
   font-size: 1.2rem;
+}
+
+h1, h2, h3, h4, h5, h6,
+.h1, .h2, .h3, .h4, .h5, .h6 {
+  margin: 0 0 20px;
+  @include var('color', 'text');
+  font-weight: 700;
+  line-height: 1;
+  word-break: break-word;
+  text-rendering: optimizeLegibility;
+  p +&, ul +&, ol +& {
+    margin-top: 40px;
+  }
+  &:last-child {
+    margin-bottom: 0;
+  }
 }

--- a/packages/next-dashboard/sass/elements/_input.scss
+++ b/packages/next-dashboard/sass/elements/_input.scss
@@ -1,3 +1,12 @@
+
+select {
+  padding: 10px (15px + 12.5px + 15px) 10px 15px;
+  background-image: url('/images/select-arrow.svg');
+  background-size: 12.5px auto;
+  background-repeat: no-repeat;
+  background-position: right 15px center;
+}
+
 [type='text'],
 [type='password'],
 [type='date'],
@@ -34,33 +43,22 @@ select {
     margin-bottom: 0;
   }
 }
-select {
-  padding: 10px (15px + 12.5px + 15px) 10px 15px;
-  background-image: url('/images/select-arrow.svg');
-  background-size: 12.5px auto;
-  background-repeat: no-repeat;
-  background-position: right 15px center;
+
+input[type="radio"] {
+  +label {
+    &:before {
+      border-radius: 50%;
+    }
+    &:after {
+      border-radius: 50%;
+    }
+  }
 }
 
-[type="checkbox"],
-[type="radio"] {
+input[type="checkbox"],
+input[type="radio"] {
   @include visually-hidden;
   margin: 20px 0 0 (20px / 2);
-  &:focus,
-  &:active {
-    +label {
-      &:before {
-        @include var('background-color', 'background-darker');
-      }
-    }
-  }
-  &:checked {
-    +label {
-      &:after {
-        display: block;
-      }
-    }
-  }
   +label {
     position: relative;
     padding: 0 0 0 20px + 10px;
@@ -91,14 +89,19 @@ select {
       background-color: $primary-color;
     }
   }
-}
-input[type="radio"] {
-  +label {
-    &:before {
-      border-radius: 50%;
+  &:focus,
+  &:active {
+    +label {
+      &:before {
+        @include var('background-color', 'background-darker');
+      }
     }
-    &:after {
-      border-radius: 50%;
+  }
+  &:checked {
+    +label {
+      &:after {
+        display: block;
+      }
     }
   }
 }

--- a/packages/next-dashboard/sass/elements/_table.scss
+++ b/packages/next-dashboard/sass/elements/_table.scss
@@ -3,6 +3,10 @@ table {
   border-collapse: collapse;
 }
 
+th {
+  font-weight: inherit;
+  text-align: left;
+}
 th,
 td {
   padding: 5px;
@@ -15,10 +19,6 @@ td {
     &:empty::after {
     content: '\00a0';
   }
-}
-th {
-  font-weight: inherit;
-  text-align: left;
 }
 
 .responsive-table {
@@ -35,7 +35,6 @@ th {
   flex: 0 0 33.33333%;
   max-width: 33.33333%;
   border-right: 1px solid;
-  z-index: 1;
   overflow: hidden;
   @include var('border-color', 'primary-rgb', 'rgba', 0.25);
   @include breakpoint(medium) {

--- a/packages/next-dashboard/sass/layouts/_content.scss
+++ b/packages/next-dashboard/sass/layouts/_content.scss
@@ -1,11 +1,3 @@
-body {
-  &.body_resizing {
-    .dashboard-content {
-      transition: none;
-    }
-  }
-}
-
 .dashboard-content {
   flex: 1 0 auto;
   padding: (80px + 20px) 0 40px;
@@ -21,6 +13,7 @@ body {
 
 }
 
+
 .dashboard_sidebar_active {
   .dashboard-content {
     @include breakpoint(medium) {
@@ -30,11 +23,17 @@ body {
       margin-left: 240px;
     }
   }
-  &.sidebar_compact {
-    .dashboard-content {
-      @include breakpoint(medium) {
-        margin-left: 86px;
-      }
+}
+
+body.body_resizing .dashboard-content {
+  transition: none;
+}
+
+
+.dashboard_sidebar_active.sidebar_compact {
+  .dashboard-content {
+    @include breakpoint(medium) {
+      margin-left: 86px;
     }
   }
 }

--- a/packages/next-dashboard/sass/layouts/_header.scss
+++ b/packages/next-dashboard/sass/layouts/_header.scss
@@ -1,16 +1,3 @@
-body {
-  &.body_resizing {
-    .dashboard-header {
-      transition: none;
-    }
-  }
-  &.body_at-top {
-    .dashboard-header {
-      box-shadow: none;
-    }
-  }
-}
-
 .dashboard-header {
   display: flex;
   align-items: center;
@@ -35,6 +22,7 @@ body {
 .dashboard-header-cell {
   flex: 0 0 auto;
   &_sidebar {
+    padding: 0 !important;
     flex: 0 0 25%;
     max-width: 25%;
     @include breakpoint(medium) {
@@ -79,10 +67,6 @@ body {
   }
 }
 
-.dashboard-header-cell_sidebar {
-  padding: 0 !important;
-}
-
 .dashboard-header-sidebar-button {
   display: block;
   position: relative;
@@ -118,5 +102,18 @@ body {
   width: calc(100% - 38px);
   @include breakpoint(large) {
     width: calc(100% - 76px);
+  }
+}
+
+body {
+  &.body_resizing {
+    .dashboard-header {
+      transition: none;
+    }
+  }
+  &.body_at-top {
+    .dashboard-header {
+      box-shadow: none;
+    }
   }
 }

--- a/packages/next-dashboard/sass/layouts/_sidebar.scss
+++ b/packages/next-dashboard/sass/layouts/_sidebar.scss
@@ -1,17 +1,14 @@
-body {
-  &.body_resizing {
-    .dashboard-sidebar {
-      transition: none;
-    }
-    .dashboard-sidebar-menu-item-button-text {
-      transition: none;
-    }
-    .dashboard-sidebar-profile {
-      .profile-content {
-        transition: none;
-      }
-    }
+.dashboard-sidebar-profile {
+  @include breakpoint(large) {
+    display: none;
   }
+  .profile-content {
+    transition: opacity 0.25s ease;
+  }
+}
+
+.dashboard-sidebar-menu-item-button-text {
+  transition: opacity 0.25s ease;
 }
 
 .dashboard-sidebar {
@@ -111,9 +108,6 @@ body {
   margin: 0 10px 0 0;
   text-align: center;
 }
-.dashboard-sidebar-menu-item-button-text {
-  transition: opacity 0.25s ease;
-}
 
 .dashboard-sidebar-search {
   margin: 0 0 20px;
@@ -133,11 +127,19 @@ body {
     }
   }
 }
-.dashboard-sidebar-profile {
-  @include breakpoint(large) {
-    display: none;
-  }
-  .profile-content {
-    transition: opacity 0.25s ease;
+
+body {
+  &.body_resizing {
+    .dashboard-sidebar {
+      transition: none;
+    }
+    .dashboard-sidebar-menu-item-button-text {
+      transition: none;
+    }
+    .dashboard-sidebar-profile {
+      .profile-content {
+        transition: none;
+      }
+    }
   }
 }


### PR DESCRIPTION
Added a style linter with a recommended base config.

A bunch of reordering [because of this rule](https://stylelint.io/user-guide/rules/no-descending-specificity)

That rule seems pretty reasonable to me, since it ensures that (at least within a file) rules have a chronological specificity:
Rules later in the file take precedence for rules earlier in the file.

I'm not SUPER invested in that rule, as there were some cases where I had to split things up in a weird way in order to satisfy that rule, and if that becomes a major issue going forward we could alter that ruleset. I did catch a few extra semicolons and whatnot though, so that's nice!