### PR TITLE
Statistics: refactor to functional component, forward props to child

### DIFF
--- a/packages/next-dashboard/src/components/Statistic.js
+++ b/packages/next-dashboard/src/components/Statistic.js
@@ -1,21 +1,72 @@
 // @flow
-import React, { PureComponent } from 'react';
+import React, { type Node } from 'react';
+import classnames from 'classnames';
 
 import type { Statuses } from '../utils/types';
 
 export type Props = {
-  label?: React$Node,
-  value: React$Node,
-  prefix?: React$Node,
-  suffix?: React$Node,
-  periodValue?: React$Node,
-  periodText?: React$Node,
-  description?: React$Node,
+  label?: Node,
+  value: Node,
+  prefix?: Node,
+  suffix?: Node,
+  periodValue?: Node,
+  periodText?: Node,
+  description?: Node,
   status?: Statuses,
   direction?: 'up' | 'down',
+  className?: string,
 };
 
-export const defaultProps = {
+function Statistic({
+  label,
+  value,
+  prefix,
+  suffix,
+  periodValue,
+  periodText,
+  description,
+  status,
+  direction,
+  className,
+  ...rest
+}: Props): Node {
+  return (
+    <div
+      className={classnames(
+        'statistic',
+        status && `statistic_status_${status}`,
+        direction && `statistic_direction_${direction}`,
+        className,
+      )}
+      {...rest}
+    >
+      <div className="label margin-bottom-x1">
+        {label != null ? label : <>&nbsp;</>}
+      </div>
+      <h2 className="margin-bottom-x1">
+        {prefix}
+        {value}
+        {suffix}
+      </h2>
+      {(periodValue || periodText) && (
+        <p>
+          {direction && (
+            <img
+              className="statistic-period-icon"
+              src={`/images/statistic/statistic-direction-icon-${direction}.svg`}
+              alt=""
+            />
+          )}
+          <span className="statistic-period-value">{periodValue}</span>{' '}
+          {periodText}
+        </p>
+      )}
+      {description != null && <p>{description}</p>}
+    </div>
+  );
+}
+
+Statistic.defaultProps = {
   label: undefined,
   prefix: '',
   suffix: '',
@@ -24,56 +75,7 @@ export const defaultProps = {
   description: undefined,
   status: undefined,
   direction: undefined,
+  className: undefined,
 };
 
-export default class Statistic extends PureComponent<Props> {
-  static defaultProps = defaultProps;
-
-  render() {
-    const {
-      label,
-      value,
-      prefix,
-      suffix,
-      periodValue,
-      periodText,
-      description,
-      status,
-      direction,
-    } = this.props;
-    return (
-      <div
-        className={[
-          'statistic',
-          status && `statistic_status_${status}`,
-          direction && `statistic_direction_${direction}`,
-        ]
-          .filter(c => c)
-          .join(' ')}
-      >
-        <div className="label margin-bottom-x1">
-          {label != null ? label : <>&nbsp;</>}
-        </div>
-        <h2 className="margin-bottom-x1">
-          {prefix}
-          {value}
-          {suffix}
-        </h2>
-        {(periodValue || periodText) && (
-          <p>
-            {direction && (
-              <img
-                className="statistic-period-icon"
-                src={`/images/statistic/statistic-direction-icon-${direction}.svg`}
-                alt=""
-              />
-            )}
-            <span className="statistic-period-value">{periodValue}</span>{' '}
-            {periodText}
-          </p>
-        )}
-        {description != null && <p>{description}</p>}
-      </div>
-    );
-  }
-}
+export default Statistic;

--- a/packages/next-dashboard/src/components/Statistic.js
+++ b/packages/next-dashboard/src/components/Statistic.js
@@ -1,17 +1,17 @@
 // @flow
-import React, { type Node } from 'react';
+import * as React from 'react';
 import classnames from 'classnames';
 
 import type { Statuses } from '../utils/types';
 
 export type Props = {
-  label?: Node,
-  value: Node,
-  prefix?: Node,
-  suffix?: Node,
-  periodValue?: Node,
-  periodText?: Node,
-  description?: Node,
+  label?: React.Node,
+  value: React.Node,
+  prefix?: React.Node,
+  suffix?: React.Node,
+  periodValue?: React.Node,
+  periodText?: React.Node,
+  description?: React.Node,
   status?: Statuses,
   direction?: 'up' | 'down',
   className?: string,
@@ -29,7 +29,7 @@ function Statistic({
   direction,
   className,
   ...rest
-}: Props): Node {
+}: Props): React.Node {
   return (
     <div
       className={classnames(


### PR DESCRIPTION
* `Statistics` is now a func comp
* `defaultProps` no longer exported
* Forward provided `className` to the topmost div
* Forward additional provided props to the topmost div

Pretty straightforward