### PR TITLE
Page chart tweaks

### DIFF
--- a/packages/next-dashboard/sass/components/_page-chart.scss
+++ b/packages/next-dashboard/sass/components/_page-chart.scss
@@ -5,7 +5,10 @@
   &:after {
     content: '';
     display: block;
-    padding: 0 0 62.5%;
+    padding: 0 0 20em;
+    @include breakpoint(extra-large) {
+      padding: 0 0 28em;
+    }
   }
 }
 .page-chart-content {

--- a/packages/next-dashboard/sass/components/_pie-chart.scss
+++ b/packages/next-dashboard/sass/components/_pie-chart.scss
@@ -11,7 +11,8 @@
 
 .pie-chart-types-list {
   display: flex;
-  justify-content: center;
+  overflow-x: auto;
+  justify-content: safe center;
   align-items: center;
   padding-top: 10px;
   margin-top: 10px;
@@ -42,4 +43,17 @@
   font-size: 16px;
   font-weight: 500;
   @include var('fill', 'text');
+}
+
+.recharts-pie-labels > .recharts-layer {
+  animation: fade-in 0.4s ease;
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
 }

--- a/packages/next-dashboard/sass/components/_radial-bar-chart.scss
+++ b/packages/next-dashboard/sass/components/_radial-bar-chart.scss
@@ -4,11 +4,15 @@
   padding-right: 24px;
   padding-top: 16px;
   font-weight: 500;
+  &.label {
+    margin-bottom: 0;
+  }
 }
 
 .radial-bar-chart-types-list {
   display: flex;
-  justify-content: center;
+  overflow-x: auto;
+  justify-content: safe center;
   align-items: center;
   padding-top: 10px;
   margin-top: 10px;

--- a/packages/next-dashboard/src/components/charts/miniCharts/HollowPieChart.js
+++ b/packages/next-dashboard/src/components/charts/miniCharts/HollowPieChart.js
@@ -17,12 +17,11 @@ import type { Plot } from './types';
 import {
   INNER_RADIUS,
   OUTER_RADIUS,
-  PADDING,
   radius,
   pieRadius,
+  getCenter,
+  renderCustomLegend,
 } from './utils';
-
-import { RENDER_ISSUE_OFFSET_PADDING } from './rechartsCorrections';
 
 type Props<T: Plot> = {
   plots: $ReadOnlyArray<T>,
@@ -68,31 +67,11 @@ export default function HollowPieChart<T: Plot>({
                 key="pie-chart-key"
                 verticalAlign="bottom"
                 iconType="circle"
-                wrapperStyle={{
-                  bottom: -14,
-                }}
-                content={({ payload }) => (
-                  <ul className="pie-chart-types-list">
-                    {payload.map(entry => (
-                      <li key={entry.value} className="pie-chart-type">
-                        <div
-                          className="pie-chart-type-color"
-                          style={{ backgroundColor: entry.color }}
-                        />
-                        {entry.value}
-                      </li>
-                    ))}
-                  </ul>
-                )}
+                wrapperStyle={{ bottom: -14 }}
+                content={renderCustomLegend}
               />
               <Pie
-                cy={
-                  height / 2 -
-                  PADDING.BOTTOM +
-                  PADDING.TOP -
-                  RENDER_ISSUE_OFFSET_PADDING
-                }
-                cx={width / 2 - PADDING.RIGHT + PADDING.LEFT}
+                {...getCenter(width, height)}
                 data={plots}
                 innerRadius={pieRadius(INNER_RADIUS, width, height)}
                 outerRadius={pieRadius(OUTER_RADIUS, width, height)}

--- a/packages/next-dashboard/src/components/charts/miniCharts/PieChart.js
+++ b/packages/next-dashboard/src/components/charts/miniCharts/PieChart.js
@@ -12,9 +12,12 @@ import PageChart from '../PageChart';
 import RenderCustomizedPieLabel from './RenderCustomizedPieLabel';
 import type { Plot } from './types';
 
-import { PADDING, OUTER_RADIUS, pieRadius } from './utils';
-
-import { RENDER_ISSUE_OFFSET_PADDING } from './rechartsCorrections';
+import {
+  OUTER_RADIUS,
+  pieRadius,
+  getCenter,
+  renderCustomLegend,
+} from './utils';
 
 type Props<T: Plot> = {
   plots: $ReadOnlyArray<T>,
@@ -57,31 +60,11 @@ export default function PieChart<T: Plot>({
                 key="pie-chart-key"
                 verticalAlign="bottom"
                 iconType="circle"
-                wrapperStyle={{
-                  bottom: -14,
-                }}
-                content={({ payload }) => (
-                  <ul className="pie-chart-types-list">
-                    {payload.map(entry => (
-                      <li key={entry.value} className="pie-chart-type">
-                        <div
-                          className="pie-chart-type-color"
-                          style={{ backgroundColor: entry.color }}
-                        />
-                        {entry.value}
-                      </li>
-                    ))}
-                  </ul>
-                )}
+                wrapperStyle={{ bottom: -14 }}
+                content={renderCustomLegend}
               />
               <Pie
-                cy={
-                  height / 2 -
-                  PADDING.BOTTOM +
-                  PADDING.TOP -
-                  RENDER_ISSUE_OFFSET_PADDING
-                }
-                cx={width / 2 - PADDING.RIGHT + PADDING.LEFT}
+                {...getCenter(width, height)}
                 data={plots}
                 outerRadius={pieRadius(OUTER_RADIUS, width, height)}
                 startAngle={startAngle}

--- a/packages/next-dashboard/src/components/charts/miniCharts/RadialBarChart.js
+++ b/packages/next-dashboard/src/components/charts/miniCharts/RadialBarChart.js
@@ -68,10 +68,15 @@ export default function RadialBarChart<T: Plot>({
               startAngle={startAngle}
               endAngle={endAngle}
               data={plots}
-              cy={height / 2 - PADDING.BOTTOM + PADDING.TOP}
+              cy={
+                height / 2 -
+                PADDING.BOTTOM +
+                PADDING.TOP -
+                RENDER_ISSUE_OFFSET_PADDING
+              }
               cx={width / 2 - PADDING.RIGHT + PADDING.LEFT}
-              innerRadius={radius(INNER_RADIUS, width, height)}
-              outerRadius={radius(OUTER_RADIUS, width, height)}
+              innerRadius={radius(INNER_RADIUS, width, height) * 1.2}
+              outerRadius={radius(OUTER_RADIUS, width, height) * 1.2}
               width={width}
               height={height}
               margin={NO_MARGIN}

--- a/packages/next-dashboard/src/components/charts/miniCharts/RadialBarChart.js
+++ b/packages/next-dashboard/src/components/charts/miniCharts/RadialBarChart.js
@@ -14,7 +14,13 @@ import PageChart from '../PageChart';
 import TextComp, { type StyledText } from './TextComp';
 import type { Plot } from './types';
 
-import { INNER_RADIUS, OUTER_RADIUS, PADDING, radius } from './utils';
+import {
+  INNER_RADIUS,
+  OUTER_RADIUS,
+  radius,
+  getCenter,
+  renderCustomLegend,
+} from './utils';
 
 type Props<T: Plot> = {
   plots: $ReadOnlyArray<T>,
@@ -25,20 +31,6 @@ type Props<T: Plot> = {
   valueFormatter?: (number, T, boolean) => ?string | number,
   centerText?: StyledText | [StyledText, StyledText],
 };
-
-const renderCustomLegend = ({ payload }) => (
-  <ul className="radial-bar-chart-types-list">
-    {payload.map(entry => (
-      <li key={entry.value} className="radial-bar-chart-type">
-        <div
-          className="radial-bar-chart-type-color"
-          style={{ backgroundColor: entry.color }}
-        />
-        {entry.value}
-      </li>
-    ))}
-  </ul>
-);
 
 const getTooltipFormatter = valueFormatter => (value, name, { payload }) => [
   (valueFormatter && valueFormatter(value, payload, true)) || value,
@@ -68,13 +60,7 @@ export default function RadialBarChart<T: Plot>({
               startAngle={startAngle}
               endAngle={endAngle}
               data={plots}
-              cy={
-                height / 2 -
-                PADDING.BOTTOM +
-                PADDING.TOP -
-                RENDER_ISSUE_OFFSET_PADDING
-              }
-              cx={width / 2 - PADDING.RIGHT + PADDING.LEFT}
+              {...getCenter(width, height)}
               innerRadius={radius(INNER_RADIUS, width, height) * 1.2}
               outerRadius={radius(OUTER_RADIUS, width, height) * 1.2}
               width={width}

--- a/packages/next-dashboard/src/components/charts/miniCharts/RadialBarChart.js
+++ b/packages/next-dashboard/src/components/charts/miniCharts/RadialBarChart.js
@@ -26,6 +26,27 @@ type Props<T: Plot> = {
   centerText?: StyledText | [StyledText, StyledText],
 };
 
+const renderCustomLegend = ({ payload }) => (
+  <ul className="radial-bar-chart-types-list">
+    {payload.map(entry => (
+      <li key={entry.value} className="radial-bar-chart-type">
+        <div
+          className="radial-bar-chart-type-color"
+          style={{ backgroundColor: entry.color }}
+        />
+        {entry.value}
+      </li>
+    ))}
+  </ul>
+);
+
+const getTooltipFormatter = valueFormatter => (value, name, { payload }) => [
+  (valueFormatter && valueFormatter(value, payload, true)) || value,
+  payload.name,
+];
+
+const NO_MARGIN = { top: 0, right: 0, bottom: 0, left: 0 };
+
 export default function RadialBarChart<T: Plot>({
   plots,
   children,
@@ -53,39 +74,19 @@ export default function RadialBarChart<T: Plot>({
               outerRadius={radius(OUTER_RADIUS, width, height)}
               width={width}
               height={height}
-              margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+              margin={NO_MARGIN}
               barCategoryGap="25%"
             >
               {children}
               <Tooltip
                 labelFormatter={() => null}
-                formatter={(value, name, { payload }) => [
-                  (valueFormatter && valueFormatter(value, payload, true)) ||
-                    value,
-                  payload.name,
-                ]}
+                formatter={getTooltipFormatter(valueFormatter)}
                 isAnimationActive={false}
               />
               <Legend
-                key="radial-bar-chart-key"
                 verticalAlign="bottom"
-                iconType="circle"
-                wrapperStyle={{
-                  bottom: -14,
-                }}
-                content={({ payload }) => (
-                  <ul className="radial-bar-chart-types-list">
-                    {payload.map(entry => (
-                      <li key={entry.value} className="radial-bar-chart-type">
-                        <div
-                          className="radial-bar-chart-type-color"
-                          style={{ backgroundColor: entry.color }}
-                        />
-                        {entry.value}
-                      </li>
-                    ))}
-                  </ul>
-                )}
+                wrapperStyle={{ bottom: -14 }}
+                content={renderCustomLegend}
               />
               <PolarAngleAxis type="number" tick={false} domain={domain} />
               <RadialBar

--- a/packages/next-dashboard/src/components/charts/miniCharts/utils.js
+++ b/packages/next-dashboard/src/components/charts/miniCharts/utils.js
@@ -1,6 +1,9 @@
 // @flow
-
-import { RENDER_ISSUE_OFFSET_SIZE } from './rechartsCorrections';
+import React from 'react';
+import {
+  RENDER_ISSUE_OFFSET_SIZE,
+  RENDER_ISSUE_OFFSET_PADDING,
+} from './rechartsCorrections';
 
 export const PADDING = {
   TOP: 0,
@@ -27,3 +30,33 @@ export const radius = (ratio: number, width: number, height: number) =>
       width - PADDING.LEFT * 2 - PADDING.RIGHT * 2,
     )) /
   2;
+
+export const getCenter = (width: number, height: number) => ({
+  cy: height / 2 - PADDING.BOTTOM + PADDING.TOP - RENDER_ISSUE_OFFSET_PADDING,
+  cx: width / 2 - PADDING.RIGHT + PADDING.LEFT,
+});
+
+type LegendPayload = {
+  value: string,
+  id: mixed,
+  type: mixed,
+  color: string,
+  inactive?: boolean,
+};
+type CustomLegendProps = {
+  payload: LegendPayload[],
+};
+
+export const renderCustomLegend = ({ payload }: CustomLegendProps) => (
+  <ul className="radial-bar-chart-types-list">
+    {payload.map(entry => (
+      <li key={entry.value} className="radial-bar-chart-type">
+        <div
+          className="radial-bar-chart-type-color"
+          style={{ backgroundColor: entry.color }}
+        />
+        {entry.value}
+      </li>
+    ))}
+  </ul>
+);


### PR DESCRIPTION
Adjusts the styling of bar charts a bit, along with some minor code cleanup.

* Extract out common code from charts into utility functions
* Make sure the center for all charts is uniform
* Increase the size of the RadialBarChart a bit for better visual balance with the pie charts (the pie charts have labels around them)
* Styling: uniform 20em (or 28em if extra-large) height for charts
* Styling: add a slight fade-in to pie chart labels
* Styling: make sure the legends don't overflow the edge of the box