### PR TITLE
Assorted improvements

### DIFF
--- a/packages/next-dashboard/sass/components/_fader.scss
+++ b/packages/next-dashboard/sass/components/_fader.scss
@@ -2,5 +2,6 @@
   &__updating {
     opacity: 0.3;
     pointer-events: none;
+    user-select: none;
   }
 }

--- a/packages/next-dashboard/sass/components/_page-table.scss
+++ b/packages/next-dashboard/sass/components/_page-table.scss
@@ -58,4 +58,9 @@
         }
       }
     }
+
+    &.sortable-table th {
+      cursor: pointer;
+      user-select: none;
+    }
   }

--- a/packages/next-dashboard/src/components/StackedVerticalBarChart.js
+++ b/packages/next-dashboard/src/components/StackedVerticalBarChart.js
@@ -11,6 +11,7 @@ import {
   Legend,
 } from 'recharts';
 import { currencyFormat } from '../utils/numberFormatters';
+import { DataNotFound } from './utils';
 
 type Props<D: {}> = {
   title?: string,
@@ -113,18 +114,9 @@ const Chart = <D: {}>({
     </div>
   );
 
-  const dataNotFound = (
-    <h3
-      className="line-chart-title-container h3-size"
-      style={{ paddingTop: 0, paddingBottom: 38 }}
-    >
-      No Data found
-    </h3>
-  );
-
   return (
     <div className="page-content" style={{ padding: 0, height: '100%' }}>
-      {(!data || data.length < 1) && !loading ? dataNotFound : chart}
+      {(!data || data.length < 1) && !loading ? <DataNotFound /> : chart}
     </div>
   );
 };

--- a/packages/next-dashboard/src/components/VerticalBarChart.js
+++ b/packages/next-dashboard/src/components/VerticalBarChart.js
@@ -11,6 +11,7 @@ import {
   Bar,
   Legend,
 } from 'recharts';
+import { DataNotFound, DataIsLoading } from './utils';
 
 type Props = {
   title: string,
@@ -106,29 +107,11 @@ const Chart = ({ title, data, loading, barChartKeysAndColor }: Props) => {
     </div>
   );
 
-  const dataNotFound = (
-    <h3
-      className="line-chart-title-container h3-size"
-      style={{ paddingTop: 0, paddingBottom: 38 }}
-    >
-      No Data found
-    </h3>
-  );
-
-  const isLoading = (
-    <h3
-      className="line-chart-title-container h3-size"
-      style={{ paddingTop: 0, paddingBottom: 38 }}
-    >
-      Loading
-    </h3>
-  );
-
   return (
     <div className="page-content" style={{ padding: 0 }}>
       <h2 className="line-chart-title-container h3-size">{title}</h2>
-      {loading ? isLoading : null}
-      {(!data || data.length < 1) && !loading ? dataNotFound : chart}
+      {loading ? <DataIsLoading /> : null}
+      {(!data || data.length < 1) && !loading ? <DataNotFound /> : chart}
     </div>
   );
 };

--- a/packages/next-dashboard/src/components/charts/Chart.js
+++ b/packages/next-dashboard/src/components/charts/Chart.js
@@ -13,6 +13,7 @@ import {
   Legend,
 } from 'recharts';
 import PageChart from './PageChart';
+import { DataNotFound, DataIsLoading } from '../utils';
 
 type Props = {
   title: string,
@@ -118,29 +119,11 @@ const Chart = ({
     </PageChart>
   );
 
-  const dataNotFound = (
-    <h3
-      className="line-chart-title-container h3-size"
-      style={{ paddingTop: 0, paddingBottom: 38 }}
-    >
-      No Data found
-    </h3>
-  );
-
-  const isLoading = (
-    <h3
-      className="line-chart-title-container h3-size"
-      style={{ paddingTop: 0, paddingBottom: 38 }}
-    >
-      Loading
-    </h3>
-  );
-
   return (
     <div className="page-content" style={{ padding: 0 }}>
       <h2 className="line-chart-title-container h3-size">{title}</h2>
-      {loading ? isLoading : null}
-      {(!data || data.length < 1) && !loading ? dataNotFound : chart}
+      {loading ? <DataIsLoading /> : null}
+      {(!data || data.length < 1) && !loading ? <DataNotFound /> : chart}
     </div>
   );
 };

--- a/packages/next-dashboard/src/components/charts/LineChart.js
+++ b/packages/next-dashboard/src/components/charts/LineChart.js
@@ -11,6 +11,7 @@ import {
   Tooltip,
 } from 'recharts';
 import PageChart from './PageChart';
+import { DataNotFound, DataIsLoading } from '../utils';
 
 type Props = {
   title: string,
@@ -60,29 +61,11 @@ const LineChart = ({ title, data, chartLineColor, loading }: Props) => {
     </PageChart>
   );
 
-  const dataNotFound = (
-    <h3
-      className="line-chart-title-container h3-size"
-      style={{ paddingTop: 0, paddingBottom: 38 }}
-    >
-      No Data found
-    </h3>
-  );
-
-  const isLoading = (
-    <h3
-      className="line-chart-title-container h3-size"
-      style={{ paddingTop: 0, paddingBottom: 38 }}
-    >
-      Loading
-    </h3>
-  );
-
   return (
     <div className="page-content" style={{ padding: 0 }}>
       <h2 className="line-chart-title-container h3-size">{title}</h2>
-      {loading ? isLoading : null}
-      {(!data || data.length < 1) && !loading ? dataNotFound : chart}
+      {loading ? <DataIsLoading /> : null}
+      {(!data || data.length < 1) && !loading ? <DataNotFound /> : chart}
     </div>
   );
 };

--- a/packages/next-dashboard/src/components/utils.js
+++ b/packages/next-dashboard/src/components/utils.js
@@ -1,0 +1,17 @@
+// @flow
+import React from 'react';
+
+const PlaceholderMessage = ({ message }: { message: string }) => (
+  <h3
+    className="line-chart-title-container h3-size"
+    style={{ paddingTop: 10, paddingBottom: 38 }}
+  >
+    {message}
+  </h3>
+);
+
+export const DataNotFound = () => (
+  <PlaceholderMessage message="No data found" />
+);
+
+export const DataIsLoading = () => <PlaceholderMessage message="Loading" />;


### PR DESCRIPTION
* Fader: disallow content selection whilst updating
* charts: extract common placeholder components (loading & no-data-found)
* SortableTable: implement `compareBy` prop. Often it's unnecessary to define a full comparator, when you just need to extract the value to sort by with some more logic. Defaults to plain `(entry, field) => entry[field]`
* SortableTable: headings show pointer cursor & disallow selection, to make the interaction with sortability more fluid

Only the `compareBy` bit changes the external interface.