### PR TITLE
Moved recharts drop shadow to base svg element

### DIFF
--- a/packages/next-dashboard/sass/components/_page-chart.scss
+++ b/packages/next-dashboard/sass/components/_page-chart.scss
@@ -77,6 +77,7 @@
 }
 .recharts-surface {
   overflow: visible;
+  filter: drop-shadow(0 5px 10px rgba(0,0,0, 0.20));  
 }
 .recharts-responsive-container {
   height: calc(100% - 14px) !important;

--- a/packages/next-dashboard/sass/components/_pie-chart.scss
+++ b/packages/next-dashboard/sass/components/_pie-chart.scss
@@ -57,7 +57,3 @@
     opacity: 1;
   }
 }
-
-g.recharts-pie-sector > path.recharts-sector {
-  filter: drop-shadow(0 5px 10px rgba(0,0,0, 0.20));
-}

--- a/packages/next-dashboard/sass/components/_radial-bar-chart.scss
+++ b/packages/next-dashboard/sass/components/_radial-bar-chart.scss
@@ -47,8 +47,3 @@ text.radial-bar-chart__center-text {
     @include var('fill', 'text-alt');
   }
 }
-
-path.recharts-radial-bar-sector,
-path.recharts-radial-bar-background-sector {
-  filter: drop-shadow(0 5px 7px rgba(0,0,0, 0.20));
-}


### PR DESCRIPTION
So, in chrome, `filter: drop-shadow();` is only supported on the base SVG element, not components within it.
This commit does not emulate the identical behaviour, where only certain elements of the charts had drop shadows,
but I still consider having drop shadows under things like the text is worth having consistent drop shadows at all.